### PR TITLE
Gjorde det enklare att kompilera reseplaneraren med gcc.

### DIFF
--- a/uppgifter/fas1/sprint2/reseplanerare/Makefile
+++ b/uppgifter/fas1/sprint2/reseplanerare/Makefile
@@ -1,42 +1,43 @@
-CCOPTS=-g -ggdb -Wall -Werror
+CC     = clang
+CCOPTS = -g -ggdb -Wall -Werror -std=c11 -D_GNU_SOURCE
 
 CODEFILES=$(shell ls *.c *.h)
 
 all: doc test
 
 main: main.c network.o util.o
-	clang $(CCOPTS) network.o graph.o util.o list.o main.c -o main
+	$(CC) $(CCOPTS) network.o graph.o util.o list.o main.c -o main
 
 doc: $(CODEFILES)
 	doxygen travel_planner.doxy
 
 network.o: graph.o network.c network.h
-	clang $(CCOPTS) -c network.c
+	$(CC) $(CCOPTS) -c network.c
 
 graph.o: list.o graph.c graph.h util.o
-	clang $(CCOPTS) -c graph.c
+	$(CC) $(CCOPTS) -c graph.c
 
 list.o: list.c list.h util.o
-	clang $(CCOPTS) -c list.c
+	$(CC) $(CCOPTS) -c list.c
 
 util.o: util.h util.c
-	clang $(CCOPTS) -c util.c
+	$(CC) $(CCOPTS) -c util.c
 
 test: main list_test graph_test network_test
 .PHONY: test
 
 list_test: list_test.c list.o util.o
-	clang $(CCOPTS) -lcunit list_test.c list.o util.o -o list_test
+	$(CC) $(CCOPTS) list_test.c list.o util.o -lcunit -o list_test
 	./list_test
 .PHONY: list_test
 
 graph_test: graph_test.c graph.o list.o
-	clang $(CCOPTS) -lcunit graph_test.c graph.o list.o util.o -o graph_test
+	$(CC) $(CCOPTS) graph_test.c graph.o list.o util.o -lcunit -o graph_test
 	./graph_test
 .PHONY: graph_test
 
 network_test: network_test.c network.o graph.o list.o
-	clang $(CCOPTS) -lcunit network_test.c network.o graph.o list.o util.o -o network_test
+	$(CC) $(CCOPTS) network_test.c network.o graph.o list.o util.o -lcunit -o network_test
 	./network_test
 .PHONY: network_test
 


### PR DESCRIPTION
Den bör i övrigt vara identisk med den föregående makefilen, har testat med både clang 3.4 och gcc 4.8.4.
